### PR TITLE
Fixes invalid JSON

### DIFF
--- a/movies/2009/star-trek.json
+++ b/movies/2009/star-trek.json
@@ -10,7 +10,7 @@
   "release-date": "2009-05-08",
   "director": "J.J. Abrams",
   "writer": [
-    "Roberto Orci"
+    "Roberto Orci",
     "Alex Kurtzman"
   ],
   "actors": [


### PR DESCRIPTION
I spotted a bug in `star-trek.json`: the `writer` array was missing a comma between its entries.