### PR TITLE
Removing duplicate (`julia-Roberts.json`)

### DIFF
--- a/actors/julia-Roberts.json
+++ b/actors/julia-Roberts.json
@@ -1,6 +1,0 @@
-{
-  "name": "Julia Roberts",
-  "birthname": "Julia Fiona Roberts",
-  "birthdate": "1967-10-28",
-  "birthplace": "Smyrna, Georgia, United States"
-}


### PR DESCRIPTION
I noticed that there are two **identical** files for Julia Roberts, so I deleted the one with the incorrect name (`julia-Roberts.json`), and kept `julia-roberts.json`.