### PR TITLE
Raise-the-Titanic

### DIFF
--- a/movies/1980/raise-the-titanic.json
+++ b/movies/1980/raise-the-titanic.json
@@ -1,0 +1,17 @@
+{
+  "name": "Raise the Titanic",
+  "year": 1980,
+  "runtime": 115,
+  "categories": [
+    "action",
+    "drama",
+    "thriller"
+  ],
+  "release-date": "1980",
+  "director": "Jerry Jameson",
+  "actors": [
+    "Jason Robards",
+    "Richard Jordan",
+    "David Selby"
+  ]
+}


### PR DESCRIPTION
To obtain a supply of a rare mineral, a ship raising operation is conducted for the only known source, the Titanic.


